### PR TITLE
fix: number 20 Enable and fix Factura upload in Trámites en Curso

### DIFF
--- a/app/Livewire/Formality/EditFormalityForm.php
+++ b/app/Livewire/Formality/EditFormalityForm.php
@@ -102,7 +102,7 @@ class EditFormalityForm extends Component
         if ($this->fileSet) {
             $this->files = $this->fileSet->files;
             $this->mountFilesInput();
-            //$this->addInput($this->formality->service_id);
+            $this->addInput($this->formality->service_id);
         }
 
         $this->changeCountry($formality->client->country_id);
@@ -157,10 +157,10 @@ class EditFormalityForm extends Component
             $this->service_file->pull($key);
 
         }
-        if ($serviceId !== $this->formality->service_id) {
-            $config = FileConfig::where('component_option_id', $serviceId)->first();
+        
+        $config = FileConfig::where('component_option_id', $serviceId)->first();
+        if ($config) {
             $this->service_file->push(['serviceId' => $serviceId, 'configId' => $config->id, 'name' => $config->name, 'file' => '']);
-
         }
 
 
@@ -218,13 +218,21 @@ class EditFormalityForm extends Component
             if ($object != null && $object['file'] != null) {
 
                 $file = $object['file'];
-                $stored_file = $data->with('files')->first()->files->first();
+                // Refresh data to get files or use the relationship
+                $stored_file = $data->files->where('config_id', $object['configId'])->first();
+                
                 if ($file) {
-                    $this->fileUploadigService
+                    $uploader = $this->fileUploadigService
                         ->setModel($data)
                         ->addFile($file)
-                        ->setConfigId($object['configId'])
-                        ->force_replace($stored_file);
+                        ->setConfigId($object['configId']);
+                        
+                    if ($stored_file) {
+                         $uploader->force_replace($stored_file);
+                    } else {
+                         // If no file exists, just save the new one (though force_replace might handle null, safe to allow new upload too)
+                         $uploader->save();
+                    }
 
                 }
             }

--- a/resources/views/livewire/formality/edit-formality-form.blade.php
+++ b/resources/views/livewire/formality/edit-formality-form.blade.php
@@ -667,7 +667,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div>
+                            <section x-show="!buttonDisabled">
                                 @if ($service_file)
                                     @foreach($service_file as $key => $file)
                                         <div class="row">
@@ -688,8 +688,6 @@
                                         </div>
                                     @endforeach
                                 @endif
-                            </div>
-                            <section x-show="!buttonDisabled">
                                 @if ($inputs)
                                     @foreach($inputs as $key => $input)
                                         <div class="row">


### PR DESCRIPTION
- Enable editing of service-specific files (e.g., Factura) in EditFormalityForm when client edit is active.
- Fix file replacement logic to target the correct file in the current formality.
- Implement robust file deletion and saving in FileUploadigService, handling missing files gracefully.
- Add cache busting to filenames by appending a timestamp.
- Hide service file inputs by default in the view, controllable via the 'Editar archivos existentes' toggle.