### PR TITLE
fix(admin): restrict access to ticket and formality modification

### DIFF
--- a/app/Http/Controllers/Admin/Formality/FormalityAdminController.php
+++ b/app/Http/Controllers/Admin/Formality/FormalityAdminController.php
@@ -102,6 +102,10 @@ class FormalityAdminController extends Controller
         $from = $request->input('from');
 
         
+        if (auth()->user()->hasRole('inmobiliaria')) {
+            abort(403);
+        }
+
         if ($from === 'total' && !auth()->user()->can('formality.totalInProgress.access')) {
             abort(403);
         }

--- a/app/Http/Controllers/Admin/Ticket/TicketAdminController.php
+++ b/app/Http/Controllers/Admin/Ticket/TicketAdminController.php
@@ -23,6 +23,8 @@ class TicketAdminController extends Controller
         $this->middleware('can:ticket.total.closed.access')->only('getTotalClosed');
         $this->middleware('can:ticket.assignment.access')->only('getAssignment');
         $this->middleware('can:ticket.total.pending.access')->only('getTotalPending');
+        $this->middleware('can:ticket.pending.access')->only('edit');
+        $this->middleware('can:ticket.resolved.access')->only('getView');
     }
 
     public function create()
@@ -102,6 +104,10 @@ class TicketAdminController extends Controller
 
     public function modify(int $id, Request $request)
     {
+        if (auth()->user()->hasRole('inmobiliaria')) {
+            abort(403);
+        }
+
         $from = $request->query('from');
         $program = Program::where('name', operator: 'tickets asignados')->first();
 


### PR DESCRIPTION
- Explicitly abort(403) for 'inmobiliaria' role in FormalityAdminController::modify and TicketAdminController::modify.
- Add middleware protection for TicketAdminController edit and getView methods.